### PR TITLE
Fix issue when filtering nested array

### DIFF
--- a/.github/workflows/jsonpath.yaml
+++ b/.github/workflows/jsonpath.yaml
@@ -1,5 +1,11 @@
 name: ci
-on: [pull_request, pull_request_target, push]
+on:
+  push:
+    branches: 
+    - master
+    tags:
+    - v*
+  pull_request: 
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,15 @@
+name: ci
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Go ${{ matrix.go }} test
+    strategy:
+      matrix:
+        go: ["1.16", "1.17"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
+      - run: go test -v ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,5 @@
 name: ci
-on: push
+on: [pull_request, pull_request_target, push]
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -109,7 +109,7 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 		case "range":
 			if len(s.key) > 0 {
 				// no key `$[:1].test`
-				obj, err = get_key_with_flatening(obj, s.key, true)
+				obj, err = get_key_with_flattening(obj, s.key, true)
 				if err != nil {
 					return nil, err
 				}
@@ -127,7 +127,7 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 				return nil, fmt.Errorf("range args length should be 2")
 			}
 		case "filter":
-			obj, err = get_key_with_flatening(obj, s.key, true)
+			obj, err = get_key_with_flattening(obj, s.key, true)
 			if err != nil {
 				return nil, err
 			}
@@ -325,7 +325,7 @@ func filter_get_from_explicit_path(obj interface{}, path string) (interface{}, e
 	return xobj, nil
 }
 
-func get_key_with_flatening(obj interface{}, key string, isFlaten bool) (interface{}, error) {
+func get_key_with_flattening(obj interface{}, key string, isFlatten bool) (interface{}, error) {
 	if reflect.TypeOf(obj) == nil {
 		return nil, nil
 	}
@@ -356,7 +356,7 @@ func get_key_with_flatening(obj interface{}, key string, isFlaten bool) (interfa
 			if v, err := get_key(tmp, key); err == nil {
 				keyVal := reflect.ValueOf(v)
 				// flatten the value is the result is array or slice
-				if keyVal.Kind() == reflect.Slice && isFlaten {
+				if keyVal.Kind() == reflect.Slice && isFlatten {
 					for j := 0; j < keyVal.Len(); j++ {
 						res = append(res, keyVal.Index(j).Interface())
 					}
@@ -372,7 +372,7 @@ func get_key_with_flatening(obj interface{}, key string, isFlaten bool) (interfa
 }
 
 func get_key(obj interface{}, key string) (interface{}, error) {
-	return get_key_with_flatening(obj, key, false)
+	return get_key_with_flattening(obj, key, false)
 }
 
 func get_idx(obj interface{}, idx int) (interface{}, error) {

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -595,45 +595,6 @@ func parse_filter(filter string) (lp string, op string, rp string, err error) {
 	return lp, op, rp, err
 }
 
-func parse_filter_v1(filter string) (lp string, op string, rp string, err error) {
-	tmp := ""
-	istoken := false
-	for _, c := range filter {
-		if istoken == false && c != ' ' {
-			istoken = true
-		}
-		if istoken == true && c == ' ' {
-			istoken = false
-		}
-		if istoken == true {
-			tmp += string(c)
-		}
-		if istoken == false && tmp != "" {
-			if lp == "" {
-				lp = tmp[:]
-				tmp = ""
-			} else if op == "" {
-				op = tmp[:]
-				tmp = ""
-			} else if rp == "" {
-				rp = tmp[:]
-				tmp = ""
-			}
-		}
-	}
-	if tmp != "" && lp == "" && op == "" && rp == "" {
-		lp = tmp[:]
-		op = "exists"
-		rp = ""
-		err = nil
-		return
-	} else if tmp != "" && rp == "" {
-		rp = tmp[:]
-		tmp = ""
-	}
-	return lp, op, rp, err
-}
-
 func eval_reg_filter(obj, root interface{}, lp string, pat *regexp.Regexp) (res bool, err error) {
 	if pat == nil {
 		return false, errors.New("nil pat")

--- a/jsonpath.go
+++ b/jsonpath.go
@@ -354,6 +354,14 @@ func get_key(obj interface{}, key string) (interface{}, error) {
 		for i := 0; i < reflect.ValueOf(obj).Len(); i++ {
 			tmp, _ := get_idx(obj, i)
 			if v, err := get_key(tmp, key); err == nil {
+				keyVal := reflect.ValueOf(v)
+				// flatten the value if the result is array or slice
+				if keyVal.Kind() == reflect.Slice {
+					for j := 0; j < keyVal.Len(); j++ {
+						res = append(res, keyVal.Index(j).Interface())
+					}
+					continue
+				}
 				res = append(res, v)
 			}
 		}

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -14,45 +14,79 @@ var json_data interface{}
 
 func init() {
 	data := `
-{
-    "store": {
-        "book": [
-            {
-                "category": "reference",
-                "author": "Nigel Rees",
-                "title": "Sayings of the Century",
-                "price": 8.95
-            },
-            {
-                "category": "fiction",
-                "author": "Evelyn Waugh",
-                "title": "Sword of Honour",
-                "price": 12.99
-            },
-            {
-                "category": "fiction",
-                "author": "Herman Melville",
-                "title": "Moby Dick",
-                "isbn": "0-553-21311-3",
-                "price": 8.99
-            },
-            {
-                "category": "fiction",
-                "author": "J. R. R. Tolkien",
-                "title": "The Lord of the Rings",
-                "isbn": "0-395-19395-8",
-                "price": 22.99
-            }
-        ],
-        "bicycle": {
-            "color": "red",
-            "price": 19.95
-        }
-    },
-    "expensive": 10,
-	"null_array": null,
-	"empty_array": []
-}
+	{
+		"store":{
+		   "book":[
+			  {
+				 "category":"reference",
+				 "author":"Nigel Rees",
+				 "title":"Sayings of the Century",
+				 "price":8.95
+			  },
+			  {
+				 "category":"fiction",
+				 "author":"Evelyn Waugh",
+				 "title":"Sword of Honour",
+				 "price":12.99
+			  },
+			  {
+				 "category":"fiction",
+				 "author":"Herman Melville",
+				 "title":"Moby Dick",
+				 "isbn":"0-553-21311-3",
+				 "price":8.99
+			  },
+			  {
+				 "category":"fiction",
+				 "author":"J. R. R. Tolkien",
+				 "title":"The Lord of the Rings",
+				 "isbn":"0-395-19395-8",
+				 "price":22.99
+			  }
+		   ],
+		   "bicycle":{
+			  "color":"red",
+			  "price":19.95
+		   }
+		},
+		"expensive":10,
+		"null_array":null,
+		"empty_array":[],
+		"predictions":[
+		   {
+			  "data":[
+				 {
+					"price":100,
+					"id":1
+				 },
+				 {
+					"price":200,
+					"id":2
+				 },
+				 {
+					"price":300,
+					"id":3
+				 }
+			  ]
+		   },
+		   {
+			"data":[
+			   {
+				  "price":50,
+				  "id":5
+			   },
+			   {
+				  "price":200,
+				  "id": 4
+			   },
+			   {
+				  "price":700,
+				  "id":9
+			   }
+			]
+		 }
+		]
+	 }
 `
 	json.Unmarshal([]byte(data), &json_data)
 }
@@ -150,6 +184,17 @@ func Test_jsonpath_JsonPathLookup_filter(t *testing.T) {
 		}
 	}
 
+	// filter with nested array
+	res, err = JsonPathLookup(json_data, "$.predictions[*].data[?(@.price > 200)].id")
+	t.Log(err, res)
+	res_v, ok := res.([]interface{})
+	if !ok {
+		t.Errorf("error: %v", res)
+	}
+	if res_v[0].(float64) != 3 || res_v[1].(float64) != 9 {
+		t.Errorf("error: %v", res)
+	}
+
 	res, err = JsonPathLookup(json_data, "$.store.book[?(@.price > 10)]")
 	t.Log(err, res)
 
@@ -172,63 +217,63 @@ func Test_jsonpath_authors_of_all_books(t *testing.T) {
 }
 
 var token_cases = []map[string]interface{}{
-	map[string]interface{}{
+	{
 		"query":  "$..author",
 		"tokens": []string{"$", "*", "author"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$.store.*",
 		"tokens": []string{"$", "store", "*"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$.store..price",
 		"tokens": []string{"$", "store", "*", "price"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$.store.book[*].author",
 		"tokens": []string{"$", "store", "book[*]", "author"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[2]",
 		"tokens": []string{"$", "*", "book[2]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[(@.length-1)]",
 		"tokens": []string{"$", "*", "book[(@.length-1)]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[0,1]",
 		"tokens": []string{"$", "*", "book[0,1]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[:2]",
 		"tokens": []string{"$", "*", "book[:2]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[?(@.isbn)]",
 		"tokens": []string{"$", "*", "book[?(@.isbn)]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$.store.book[?(@.price < 10)]",
 		"tokens": []string{"$", "store", "book[?(@.price < 10)]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[?(@.price <= $.expensive)]",
 		"tokens": []string{"$", "*", "book[?(@.price <= $.expensive)]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[?(@.author =~ /.*REES/i)]",
 		"tokens": []string{"$", "*", "book[?(@.author =~ /.*REES/i)]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..book[?(@.author =~ /.*REES\\]/i)]",
 		"tokens": []string{"$", "*", "book[?(@.author =~ /.*REES\\]/i)]"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$..*",
 		"tokens": []string{"$", "*"},
 	},
-	map[string]interface{}{
+	{
 		"query":  "$....author",
 		"tokens": []string{"$", "*", "author"},
 	},
@@ -254,14 +299,13 @@ func Test_jsonpath_tokenize(t *testing.T) {
 }
 
 var parse_token_cases = []map[string]interface{}{
-
-	map[string]interface{}{
+	{
 		"token": "$",
 		"op":    "root",
 		"key":   "$",
 		"args":  nil,
 	},
-	map[string]interface{}{
+	{
 		"token": "store",
 		"op":    "key",
 		"key":   "store",
@@ -269,25 +313,25 @@ var parse_token_cases = []map[string]interface{}{
 	},
 
 	// idx --------------------------------------
-	map[string]interface{}{
+	{
 		"token": "book[2]",
 		"op":    "idx",
 		"key":   "book",
 		"args":  []int{2},
 	},
-	map[string]interface{}{
+	{
 		"token": "book[-1]",
 		"op":    "idx",
 		"key":   "book",
 		"args":  []int{-1},
 	},
-	map[string]interface{}{
+	{
 		"token": "book[0,1]",
 		"op":    "idx",
 		"key":   "book",
 		"args":  []int{0, 1},
 	},
-	map[string]interface{}{
+	{
 		"token": "[0]",
 		"op":    "idx",
 		"key":   "",
@@ -295,25 +339,25 @@ var parse_token_cases = []map[string]interface{}{
 	},
 
 	// range ------------------------------------
-	map[string]interface{}{
+	{
 		"token": "book[1:-1]",
 		"op":    "range",
 		"key":   "book",
 		"args":  [2]interface{}{1, -1},
 	},
-	map[string]interface{}{
+	{
 		"token": "book[*]",
 		"op":    "range",
 		"key":   "book",
 		"args":  [2]interface{}{nil, nil},
 	},
-	map[string]interface{}{
+	{
 		"token": "book[:2]",
 		"op":    "range",
 		"key":   "book",
 		"args":  [2]interface{}{nil, 2},
 	},
-	map[string]interface{}{
+	{
 		"token": "book[-2:]",
 		"op":    "range",
 		"key":   "book",
@@ -321,31 +365,31 @@ var parse_token_cases = []map[string]interface{}{
 	},
 
 	// filter --------------------------------
-	map[string]interface{}{
+	{
 		"token": "book[?( @.isbn      )]",
 		"op":    "filter",
 		"key":   "book",
 		"args":  "@.isbn",
 	},
-	map[string]interface{}{
+	{
 		"token": "book[?(@.price < 10)]",
 		"op":    "filter",
 		"key":   "book",
 		"args":  "@.price < 10",
 	},
-	map[string]interface{}{
+	{
 		"token": "book[?(@.price <= $.expensive)]",
 		"op":    "filter",
 		"key":   "book",
 		"args":  "@.price <= $.expensive",
 	},
-	map[string]interface{}{
+	{
 		"token": "book[?(@.author =~ /.*REES/i)]",
 		"op":    "filter",
 		"key":   "book",
 		"args":  "@.author =~ /.*REES/i",
 	},
-	map[string]interface{}{
+	{
 		"token": "*",
 		"op":    "scan",
 		"key":   "*",
@@ -463,10 +507,10 @@ func Test_jsonpath_get_key(t *testing.T) {
 	}
 
 	obj4 := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"a": 1,
 		},
-		map[string]interface{}{
+		{
 			"a": 2,
 		},
 	}
@@ -597,7 +641,7 @@ func Test_jsonpath_types_eval(t *testing.T) {
 
 var tcase_parse_filter = []map[string]interface{}{
 	// 0
-	map[string]interface{}{
+	{
 		"filter":  "@.isbn",
 		"exp_lp":  "@.isbn",
 		"exp_op":  "exists",
@@ -605,7 +649,7 @@ var tcase_parse_filter = []map[string]interface{}{
 		"exp_err": nil,
 	},
 	// 1
-	map[string]interface{}{
+	{
 		"filter":  "@.price < 10",
 		"exp_lp":  "@.price",
 		"exp_op":  "<",
@@ -613,7 +657,7 @@ var tcase_parse_filter = []map[string]interface{}{
 		"exp_err": nil,
 	},
 	// 2
-	map[string]interface{}{
+	{
 		"filter":  "@.price <= $.expensive",
 		"exp_lp":  "@.price",
 		"exp_op":  "<=",
@@ -621,7 +665,7 @@ var tcase_parse_filter = []map[string]interface{}{
 		"exp_err": nil,
 	},
 	// 3
-	map[string]interface{}{
+	{
 		"filter":  "@.author =~ /.*REES/i",
 		"exp_lp":  "@.author",
 		"exp_op":  "=~",
@@ -661,37 +705,37 @@ func Test_jsonpath_parse_filter(t *testing.T) {
 
 var tcase_filter_get_from_explicit_path = []map[string]interface{}{
 	// 0
-	map[string]interface{}{
+	{
 		// 0 {"a": 1}
 		"obj":      map[string]interface{}{"a": 1},
 		"query":    "$.a",
 		"expected": 1,
 	},
-	map[string]interface{}{
+	{
 		// 1 {"a":{"b":1}}
 		"obj":      map[string]interface{}{"a": map[string]interface{}{"b": 1}},
 		"query":    "$.a.b",
 		"expected": 1,
 	},
-	map[string]interface{}{
+	{
 		// 2 {"a": {"b":1, "c":2}}
 		"obj":      map[string]interface{}{"a": map[string]interface{}{"b": 1, "c": 2}},
 		"query":    "$.a.c",
 		"expected": 2,
 	},
-	map[string]interface{}{
+	{
 		// 3 {"a": {"b":1}, "b": 2}
 		"obj":      map[string]interface{}{"a": map[string]interface{}{"b": 1}, "b": 2},
 		"query":    "$.a.b",
 		"expected": 1,
 	},
-	map[string]interface{}{
+	{
 		// 4 {"a": {"b":1}, "b": 2}
 		"obj":      map[string]interface{}{"a": map[string]interface{}{"b": 1}, "b": 2},
 		"query":    "$.b",
 		"expected": 2,
 	},
-	map[string]interface{}{
+	{
 		// 5 {'a': ['b',1]}
 		"obj":      map[string]interface{}{"a": []interface{}{"b", 1}},
 		"query":    "$.a[0]",
@@ -730,7 +774,7 @@ func Test_jsonpath_filter_get_from_explicit_path(t *testing.T) {
 
 var tcase_eval_filter = []map[string]interface{}{
 	// 0
-	map[string]interface{}{
+	{
 		"obj":  map[string]interface{}{"a": 1},
 		"root": map[string]interface{}{},
 		"lp":   "@.a",
@@ -739,7 +783,7 @@ var tcase_eval_filter = []map[string]interface{}{
 		"exp":  true,
 	},
 	// 1
-	map[string]interface{}{
+	{
 		"obj":  map[string]interface{}{"a": 1},
 		"root": map[string]interface{}{},
 		"lp":   "@.b",
@@ -748,7 +792,7 @@ var tcase_eval_filter = []map[string]interface{}{
 		"exp":  false,
 	},
 	// 2
-	map[string]interface{}{
+	{
 		"obj":  map[string]interface{}{"a": 1},
 		"root": map[string]interface{}{"a": 1},
 		"lp":   "$.a",
@@ -757,7 +801,7 @@ var tcase_eval_filter = []map[string]interface{}{
 		"exp":  true,
 	},
 	// 3
-	map[string]interface{}{
+	{
 		"obj":  map[string]interface{}{"a": 1},
 		"root": map[string]interface{}{"a": 1},
 		"lp":   "$.b",
@@ -766,7 +810,7 @@ var tcase_eval_filter = []map[string]interface{}{
 		"exp":  false,
 	},
 	// 4
-	map[string]interface{}{
+	{
 		"obj":  map[string]interface{}{"a": 1, "b": map[string]interface{}{"c": 2}},
 		"root": map[string]interface{}{"a": 1, "b": map[string]interface{}{"c": 2}},
 		"lp":   "$.b.c",
@@ -775,7 +819,7 @@ var tcase_eval_filter = []map[string]interface{}{
 		"exp":  true,
 	},
 	// 5
-	map[string]interface{}{
+	{
 		"obj":  map[string]interface{}{"a": 1, "b": map[string]interface{}{"c": 2}},
 		"root": map[string]interface{}{},
 		"lp":   "$.b.a",
@@ -785,7 +829,7 @@ var tcase_eval_filter = []map[string]interface{}{
 	},
 
 	// 6
-	map[string]interface{}{
+	{
 		"obj":  map[string]interface{}{"a": 3},
 		"root": map[string]interface{}{"a": 3},
 		"lp":   "$.a",
@@ -823,43 +867,42 @@ var (
 )
 
 var tcase_cmp_any = []map[string]interface{}{
-
-	map[string]interface{}{
+	{
 		"obj1": 1,
 		"obj2": 1,
 		"op":   "==",
 		"exp":  true,
 		"err":  nil,
 	},
-	map[string]interface{}{
+	{
 		"obj1": 1,
 		"obj2": 2,
 		"op":   "==",
 		"exp":  false,
 		"err":  nil,
 	},
-	map[string]interface{}{
+	{
 		"obj1": 1.1,
 		"obj2": 2.0,
 		"op":   "<",
 		"exp":  true,
 		"err":  nil,
 	},
-	map[string]interface{}{
+	{
 		"obj1": "1",
 		"obj2": "2.0",
 		"op":   "<",
 		"exp":  true,
 		"err":  nil,
 	},
-	map[string]interface{}{
+	{
 		"obj1": "1",
 		"obj2": "2.0",
 		"op":   ">",
 		"exp":  false,
 		"err":  nil,
 	},
-	map[string]interface{}{
+	{
 		"obj1": 1,
 		"obj2": 2,
 		"op":   "=~",


### PR DESCRIPTION
We found bugs where the jsonpath is not working as expectedly when dealing with nested array. Suppose you have
```
{
    "inputs": [
        {
            "variable": [
                {
                    "name": "A",
                    "value": 200
                },
                {
                    "name": "B",
                    "value": 250
                }
            ]
        },
        {
            "variable": [
                {
                    "name": "C",
                    "value": 300
                },
                {
                    "name": "D",
                    "value": 350
                }
            ]
        }
    ]
}
```
This path `$.inputs[*].variable[?(@.value > 200)].value` should return 
```
[ 250, 300, 350]
```
but current returning 
```
[[250], [300, 350]]
```
This result is happening because there is no flattening for `range` or `filter` operation